### PR TITLE
v1.3.0, add support for transform options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Parameters for `makeStringTransform()`:
 * `transformFn(contents, transformOptions, done)` - Function which is called to
   do the transform.  `contents` are the contents of the file.  `done(err, transformed)` is
   a callback which must be called, passing the a string with the transformed contents of the
-  file.  transformOptions consists of:
+  file.  `transformOptions` consists of:
 
   * `transformOptions.file` is the name of the file (as would be passed to a normal browserify transform.)
 
@@ -60,6 +60,8 @@ Parameters for `makeStringTransform()`:
   `loadTransformConfig` below for details on where this comes from.)
 
   * `transformOptions.config` is a copy of `transformOptions.configData.config` for convenience.
+
+  * `transformOptions.opts` is an object containing any options that have been supplied to the transform (for instance, with Browserify's `b.transform` API.)
 
 * `options.excludeExtensions` - A list of extensions which will not be processed.  e.g.
   "['.coffee', '.jade']"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserify-transform-tools",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Utilities for writing browserify transforms.",
   "main": "./lib/transformTools.js",
   "repository": {

--- a/src/transformTools.coffee
+++ b/src/transformTools.coffee
@@ -50,7 +50,7 @@ exports.makeStringTransform = (transformName, options={}, transformFn) ->
         transformFn = options
         options = {}
 
-    transform = (file) ->
+    transform = (file, opts) ->
         configData = if transform.configData?
             transform.configData
         else
@@ -75,8 +75,9 @@ exports.makeStringTransform = (transformName, options={}, transformFn) ->
             try
                 transformOptions = {
                     file: file,
-                    configData, configData,
-                    config: configData?.config
+                    configData: configData,
+                    config: configData?.config,
+                    opts: opts
                 }
                 transformFn content, transformOptions, (err, transformed) =>
                     return handleError err if err


### PR DESCRIPTION
Add support for programmatically passing options to transforms, rather than requiring that options be specified in `package.json`. Bump the minor version number because this is a new, backwards-compatible feature. Finally, update the `README` to describe the new feature.