### PR TITLE
Ensure file configuration (appliesTo) is overridden correctly

### DIFF
--- a/src/skipFile.coffee
+++ b/src/skipFile.coffee
@@ -19,7 +19,7 @@ module.exports = (file, configData={}, options={}) ->
     file = path.resolve file
     skip = false
 
-    appliesTo = configData.appliesTo ? configData.config?.appliesTo
+    appliesTo = configData.appliesTo
 
     # If there's no appliesTo, then use options.
     if !appliesTo? or (

--- a/src/transformTools.coffee
+++ b/src/transformTools.coffee
@@ -73,6 +73,10 @@ exports.makeStringTransform = (transformName, options={}, transformFn) ->
             configData = clone(configData) ? {config:{}}
             configData.config = merge configData.config, config
 
+            if configData.config.appliesTo
+                configData.appliesTo = configData.config.appliesTo
+                delete configData.config.appliesTo
+
         if skipFile file, configData, options then return through()
 
         # Read the file contents into `content`

--- a/test/skipFileTest.coffee
+++ b/test/skipFileTest.coffee
@@ -84,19 +84,7 @@ describe "transformTools skipping files", ->
         assert skipFile("foo.js", configData, options), "Should skip .js files"
         assert !skipFile("foo.json", configData, options), "Should not skip .json files"
 
-    it "should respect 'includeExtensions' overrides from config", ->
-        options = {
-            appliesTo: includeExtensions: ['.js']
-        }
-        configData = {
-            config: {
-                appliesTo: includeExtensions: ['.json']
-            }
-        }
-        assert skipFile("foo.js", configData, options), "Should skip .js files"
-        assert !skipFile("foo.json", configData, options), "Should not skip .json files"
-
-    it "should respect 'exclueExtensions' overrides from config", ->
+    it "should respect 'excludeExtensions' overrides from config", ->
         options = {
             appliesTo: includeExtensions: ['.js']
 

--- a/test/stringTransformTest.coffee
+++ b/test/stringTransformTest.coffee
@@ -79,3 +79,26 @@ describe "transformTools string transforms", ->
                 assert.equal result, "x"
                 done()
 
+    it "should allow file configuration passed on construction", (done) ->
+        transform = transformTools.makeStringTransform "xify", (content, opts, cb) ->
+            if opts.configData.appliesTo
+                cb null, "x"
+            else
+                cb null, content
+
+        return transformTools.runTransform transform, dummyJsFile, {content:"lala", config: {foo: "x", appliesTo:{ includeExtensions:['.js', '.spec']}}},
+            (err, result) ->
+                assert.equal result, "x"
+                done()
+
+    it "should clean up file configuration when passed on construction", (done) ->
+        transform = transformTools.makeStringTransform "xify", (content, opts, cb) ->
+            if opts.config.foo and !opts.config.appliesTo
+                cb null, "x"
+            else
+                cb null, content
+
+        return transformTools.runTransform transform, dummyJsFile, {content:"lala", config: {foo: "x", appliesTo:{ includeExtensions:['.js', '.spec']}}},
+            (err, result) ->
+                assert.equal result, "x"
+                done()


### PR DESCRIPTION
Previously, the file configuration ``appliesTo`` was only being read from the config parameter (the programatic config) if there was no configuration in <kbd>package.json</kbd>.

In the PR, I look to address this issue.  Now, if ``appliesTo`` is set programatically it will override any existing value (such as <kbd>package.json</kbd> file configuration).

Also, this PR aligns the behaviour of ``appliesTo`` with the current documentation (https://github.com/benbria/browserify-transform-tools/wiki/Transform-Configuration):

> Configuration is taken first from data passed via options from [browserify](https://github.com/substack/node-browserify#btransformtr-opts) (either from `b.transform(tr, opts`) or from the command line.  Configuration is then loaded from package.json.  If configuration is found in both package.json and in data passed programatically, then keys from the programatic configuartion are copied over top of the configuration from package.json.

> The `appliesTo` key will be stripped from the configuration before being passed to your transform (although it is available in the `configData` if you need it for some reason.)  Note that
`appliesTo` will override the `includeExtensions` and `excludeExtensions` provided to any of the
`make*Transform()` functions.