### PR TITLE
feat(requireTransform): accept aliases for require

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ This will take all calls to `require("foo")` and transform them to `require('bar
 
 Note that `makeRequireTransform` expects your function to return the complete `require(...)` call.  This makes it possible to write require transforms which will, for example, inline resources.
 
+If you want to evaluate not just `require` calls but also other aliases you can pass in an optional attribute `requireOptions.aliases`. This attribute can be a string or an array of strings. This functionality can become handy for example if you plan on using [aliasify](https://github.com/benbria/aliasify) with [proxyquireify](https://github.com/thlorenz/proxyquireify). In this case just pass in "proxyquire" as `requireOptions.aliases` and all your `proxyquire("module")` calls can also get evaluated.
+
 Again, all other options you can pass to `makeStringTransform` are valid here, too.
 
 Loading Configuration

--- a/test/requireTransformTest.coffee
+++ b/test/requireTransformTest.coffee
@@ -114,6 +114,51 @@ describe "transformTools require transforms", ->
             assert.equal result, expectedContent
             done()
 
+    it "should accept an array of aliases for require", (done) ->
+        transform = transformTools.makeRequireTransform "requireTransform", {requireOptions: {aliases: ['foo', 'proxyquire']}}, (args, opts, cb) ->
+            if args[0] is "bar"
+                cb null, "require('baz')"
+            else if args[0] is "foobar"
+                cb null, "require('qux')"
+            else
+                cb()
+
+        content = """
+            foo('bar');
+            proxyquire('foobar');
+            """
+        expectedContent = """
+            require('baz');
+            require('qux');
+            """
+        transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+            return done err if err
+            assert.equal result, expectedContent
+            done()
+
+
+    it "should accept a string as alias for require", (done) ->
+        transform = transformTools.makeRequireTransform "requireTransform", {requireOptions: {aliases: 'foo'}}, (args, opts, cb) ->
+            if args[0] is "bar"
+                cb null, "require('baz')"
+            else if args[0] is "foobar"
+                cb null, "require('qux')"
+            else
+                cb()
+
+        content = """
+            foo('bar');
+            proxyquire('foobar');
+            """
+        expectedContent = """
+            require('baz');
+            proxyquire('foobar');
+            """
+        transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+            return done err if err
+            assert.equal result, expectedContent
+            done()
+
     it "should optionally not handle simple expressions", (done) ->
         transform = transformTools.makeRequireTransform "requireTransform",
             {evaluateArguments: false}, (args, opts, cb) ->


### PR DESCRIPTION
The makeRequireTransform function now accepts an optional
attribute "requireOptions" which is an object with an
optional attribute "aliases" which can be a string or an
array of strings. These strings are also! taken for the
require transformation alongside "require".

The implemented functionality is also tested.


I also have an idea on how to modify aliasify elegantly without any breaking changes on the api. I will submit the other PR tomorrow.