### PR TITLE
feat(makeFunctionTransform): transform arbitrary functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,33 @@ Note that `makeRequireTransform` expects your function to return the complete `r
 
 Again, all other options you can pass to `makeStringTransform` are valid here, too.
 
+Creating a Function Transform
+============================
+
+These transforms are focused on transforming arbitrary function calls:
+
+```JavaScript
+transform = transformTools.makeRequireTransform("requireTransform",
+    {evaluateArguments: true, functionNames: ["foobar"]},
+    function(functionParams, opts, cb) {
+        if (functionParams.args[0].value === "foo") {
+            return cb(null, functionParams.name + "('bar')");
+        } else {
+            return cb();
+        }
+    });
+```
+
+This will take all calls to `foobar("foo")` and transform them to `foobar('bar')`.  Note that makeFunctionTransform can parse many simple expressions, so the above would succesfully parse `foobar("f" + "oo")`, for example.  Any expression involving core JavaScript, `__filename`, `__dirname`, `path`, and `join` (where join is an alias for `path.join`) can be parsed.  Setting the `evaluateArguments` option to false will disable this behavior, in which case the source code for everything inside the ()s will be returned.
+
+Note that `makeFunctionTransform` expects your function to return the complete `[functionName](...)` call.  This makes it possible to write function transforms which will, for example, inline resources.
+
+The option `functionNames` can either be a string or an array of strings. If no functionName is provided `makeFunctionTransform` fallbacks to `require()` calls.
+
+The `functionParams` object which is passed to the given transform function has 2 attributes. The first one is `name` which is the function name The second one is `args` and is an ordered array of the function args. Each entry consists of `value` and `type`. Type can be one of these values: `Literal, Identifier, FunctionExpression, ObjectExpression, ArrayExpression`.
+
+Again, all other options you can pass to `makeStringTransform` are valid here, too.
+
 Loading Configuration
 =====================
 

--- a/src/transformTools.coffee
+++ b/src/transformTools.coffee
@@ -252,23 +252,9 @@ exports.makeRequireTransform = (transformName, options={}, transformFn) ->
         if (node.type is 'CallExpression' and node.callee.type is 'Identifier' and
         node.callee.name is 'require')
             # Parse arguemnts to calls to `require`.
-            if evaluateArguments
-                # Based on https://github.com/ForbesLindesay/rfileify.
-                dirname = path.dirname(transformOptions.file)
-                varNames = ['__filename', '__dirname', 'path', 'join']
-                vars = [transformOptions.file, dirname, path, path.join]
+            args = evaluateFunctionArgs evaluateArguments, transformOptions, node
 
-                args = node.arguments.map (arg) ->
-                    t = "return #{arg.source()}"
-                    try
-                        return Function(varNames, t).apply(null, vars)
-                    catch err
-                        # Can't evaluate the arguemnts.  Return the raw source.
-                        return arg.source()
-            else
-                args = (arg.source() for arg in node.arguments)
-
-            transformFn args, transformOptions, (err, transformed) ->
+            transformFn args.values(), transformOptions, (err, transformed) ->
                 return done err if err
                 if transformed? then node.update(transformed)
                 done()
@@ -291,6 +277,82 @@ exports.makeRequireTransform = (transformName, options={}, transformFn) ->
     #
     transform.configure = (config, configOptions = {}) ->
         answer = exports.makeRequireTransform transformName, options, transformFn
+        answer.setConfig config, configOptions
+        return answer
+
+    return transform
+
+# Create a new Browserify transform that modifies arbitrary function calls.
+#
+# The resulting transform will call `transformFn({functionName: [functionName], args: {value: [arg], type: [type]}}, tranformOptions, cb)` for every
+# given function alias in a file.  transformFn should call `cb(null, str)` with a string which will replace the
+# entire function call.
+#
+# Exmaple:
+#
+#     makeFunctionTransform "xify", {functionNames: ["baz"]}, (functionParams, cb) ->
+#         cb null, functionParams.name + "('x" + functionParams.args[0].value + "')"
+#
+# would transform calls like `baz("foo")` into `baz("xfoo")`.
+#
+# `transformName`, `options.excludeExtensions`, `options.includeExtensions`, `options.jsFilesOnly`,
+# and `tranformOptions` are the same as for `makeStringTransform()`.
+#
+# `options.functionNames` is an optional parameter which can be a string or an array of strings.
+# These strings are taken to identify function occurences in the code. If nothing is passed as a function name
+# makeFunctionTransform falls back to `require()` calls.
+#
+# By default, makeFunctionTransform will attempt to evaluate each "require" parameters.
+# makeFunctionTransform can handle variabls `__filename`, `__dirname`, `path`, and `join` (where
+# `join` is treated as `path.join`) as well as any basic JS expressions.  If the argument is
+# too complicated to parse, then makeFunctionTransform will return the source for the argument.
+# You can disable parsing by passing `options.evaluateArguments` as false.
+#
+exports.makeFunctionTransform = (transformName, options={}, transformFn) ->
+    if !transformFn?
+        transformFn = options
+        options = {}
+
+    evaluateArguments = options.evaluateArguments ? true
+
+    functionNames = []
+    if options.functionNames?
+        if Array.isArray(options.functionNames) || {}.toString.call(options.functionNames) is '[object Array]'
+            functionNames = options.functionNames
+        else if typeof options.functionNames is 'string'
+            functionNames = [options.functionNames]
+    if functionNames.length is 0
+        functionNames.push 'require'
+
+    transform = exports.makeFalafelTransform transformName, options, (node, transformOptions, done) ->
+        if (node.type is 'CallExpression' and node.callee.type is 'Identifier' and
+          node.callee.name in functionNames)
+            # Parse arguments to calls to a given function name.
+            args = evaluateFunctionArgs evaluateArguments, transformOptions, node
+
+            transformFn {name: node.callee.name, args: args}, transformOptions, (err, transformed) ->
+                return done err if err
+                if transformed? then node.update(transformed)
+                done()
+        else
+            done()
+
+    # Called to manually pass configuration data to the transform.  Configuration passed in this
+    # way will override configuration loaded from package.json.
+    #
+    # * `config` is the configuration data.
+    # * `configOptions.configFile` is the file that configuration data was loaded from.  If this
+    #   is specified and `configOptions.configDir` is not specified, then `configOptions.configDir`
+    #   will be inferred from the configFile's path.
+    # * `configOptions.configDir` is the directory the configuration was loaded from.  This is used
+    #   by some transforms to resolve relative paths.
+    #
+    # Returns a new transform that uses the configuration:
+    #
+    #     myTransform = require('myTransform').configure(...)
+    #
+    transform.configure = (config, configOptions = {}) ->
+        answer = exports.makeFunctionTransform transformName, options, transformFn
         answer.setConfig config, configOptions
         return answer
 
@@ -336,3 +398,29 @@ exports.runTransform = (transform, file, options={}, done) ->
         fs.readFile file, "utf-8", (err, content) ->
             return done err if err
             doTransform content
+
+evaluateFunctionArgs = (evaluateArguments, transformOptions, node) ->
+    if evaluateArguments
+        # Based on https://github.com/ForbesLindesay/rfileify.
+        dirname = path.dirname(transformOptions.file)
+        varNames = ['__filename', '__dirname', 'path', 'join']
+        vars = [transformOptions.file, dirname, path, path.join]
+
+        args = node.arguments.map (arg) ->
+            t = "return #{arg.source()}"
+            try
+                return {value: Function(varNames, t).apply(null, vars), type: arg.type}
+            catch err
+                # Can't evaluate the arguments.  Return the raw source.
+                return {value: arg.source(), type: arg.type}
+    else
+        args = ({value: arg.source(), type: arg.type} for arg in node.arguments)
+
+    args.values = ->
+        values = []
+        for arg in this
+            if arg.value?
+                values.push arg.value
+        values
+    
+    args

--- a/test/functionTransformTest.coffee
+++ b/test/functionTransformTest.coffee
@@ -1,0 +1,263 @@
+transformTools = require '../src/transformTools'
+browserify = require 'browserify'
+path = require 'path'
+assert = require 'assert'
+{expect} = require 'chai'
+
+dummyJsFile = path.resolve __dirname, "../testFixtures/testWithConfig/dummy.js"
+testDir = path.resolve __dirname, "../testFixtures/testWithConfig"
+
+describe "transformTools function transforms", ->
+  cwd = process.cwd()
+
+  beforeEach ->
+    process.chdir testDir
+
+  after ->
+    process.chdir cwd
+
+  it "should generate a transform for a given function name", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", {functionNames: "bar"}, (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "foo"
+        cb null, functionParams.name + "('bar')"
+      else
+        cb()
+
+    content = """
+            bar('foo');
+            qux('baz');
+            """
+    expectedContent = """
+            bar('bar');
+            qux('baz');
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+  it "should generate a transform for multiple given function names", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", {functionNames: ["bar", "qux"]}, (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "foo"
+        cb null, functionParams.name + "('bar')"
+      else if functionParams.args[0].value is "baz"
+          cb null, functionParams.name + "('foobar')"
+        else
+          cb()
+
+    content = """
+            bar('foo');
+            qux('baz');
+            """
+    expectedContent = """
+            bar('bar');
+            qux('foobar');
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+  it "should generate a transform for require as fallback when no function name is provided", (done) ->
+    transform = transformTools.makeFunctionTransform "functionTransform", (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "foo"
+        cb null, functionParams.name + "('bar')"
+      else if functionParams.args[0].value is "baz"
+          cb null, functionParams.name + "('foobar')"
+        else
+          cb()
+
+    content = """
+            require('foo');
+            require('baz');
+            """
+    expectedContent = """
+            require('bar');
+            require('foobar');
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+  it "should handle multiple function args", (done) ->
+    transform = transformTools.makeFunctionTransform "functionTransform", (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "foo" and functionParams.args[1].value is "bar"
+        cb null, functionParams.name + "('bar', 'foo')"
+      else
+        cb()
+
+    content = """
+            require('foo', 'bar');
+            require('baz');
+            """
+    expectedContent = """
+            require('bar', 'foo');
+            require('baz');
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+  it "should pass the correct arg type", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", {functionNames: "bar"}, (functionParams, opts, cb) ->
+      concat = ""
+      for arg in functionParams.args
+        concat += "#{arg.type} "
+      cb(null, concat)
+
+    content = """
+            bar('foo', foo, function foo(){}, {}, []);
+            """
+    expectedContent = "Literal Identifier FunctionExpression ObjectExpression ArrayExpression ;"
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+  it "should allow load options from configuration", (done) ->
+    transform = transformTools.makeFunctionTransform "fooify", (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "foo"
+        cb null, functionParams.name + "('#{opts.config.foo}')"
+      else
+        cb()
+
+    content = """
+            require('foo');
+            require('baz');
+            """
+    expectedContent = """
+            require('bar');
+            require('baz');
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+  it "should allow manual configuration to override existing configuration", (done) ->
+    transform = transformTools.makeFunctionTransform "fooify", (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "foo"
+        cb null, functionParams.name + "('#{opts.config.foo}')"
+      else
+        cb()
+    transform = transform.configure {foo: "qux"}
+
+    content = """
+            require('foo');
+            require('baz');
+            """
+    expectedContent = """
+            require('qux');
+            require('baz');
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+
+      transform = transform.setConfig {foo: "zam"}
+
+      content = """
+                require('foo');
+                require('baz');
+                """
+      expectedContent = """
+                require('zam');
+                require('baz');
+                """
+      transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+        return done err if err
+        assert.equal result, expectedContent
+        done()
+
+  it "should handle simple expressions", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "foo"
+        cb null, functionParams.name + "('bar')"
+      else if functionParams.args[0].value is "a/b"
+        cb null, functionParams.name + "('qux')"
+      else
+        cb()
+
+    content = """
+            require('fo' + 'o');
+            require(path.join('a', 'b'));
+            """
+    expectedContent = """
+            require('bar');
+            require('qux');
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+  it "should optionally not handle simple expressions", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", {evaluateArguments: false}, (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "'foo'"
+        cb null, functionParams.name + "('bar')"
+      else
+        cb()
+
+    content = """
+            require('foo');
+            require(path.join('a', 'b'));
+            """
+    expectedContent = """
+            require('bar');
+            require(path.join('a', 'b'));
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+  it "should not gak on expression it doesn't understand", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", (functionParams, opts, cb) ->
+      if functionParams.args[0].value is "foo"
+        cb null, functionParams.name + "('bar')"
+      else
+        cb()
+
+    content = """
+            require(x + y);
+            require('foo');
+            """
+    expectedContent = """
+            require(x + y);
+            require('bar');
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      return done err if err
+      assert.equal result, expectedContent
+      done()
+
+
+  it "should return an error when require transform returns an error", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", (functionParams, opts, cb) ->
+      cb new Error("foo")
+
+    transformTools.runTransform transform, dummyJsFile, {content:"require('boo');"}, (err, result) ->
+      expect(err.message).to.match /foo \(while requireTransform was processing .*\/testFixtures\/testWithConfig\/dummy\.js\)/
+      done()
+
+  it "should return an error when require transform throws an error", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", (functionParams, opts, cb) ->
+      throw new Error("foo")
+
+    transformTools.runTransform transform, dummyJsFile, {content:"require('boo');"}, (err, result) ->
+      expect(err.message).to.match /foo \(while requireTransform was processing .*\/testFixtures\/testWithConfig\/dummy\.js\)/
+      done()
+
+  it "should gracefully handle a syntax error", (done) ->
+    transform = transformTools.makeFunctionTransform "requireTransform", (functionParams, opts, cb) ->
+      cb()
+
+    content = """
+            require('foo');
+            require({;
+            """
+    transformTools.runTransform transform, dummyJsFile, {content}, (err, result) ->
+      assert err != null, "Expected an error from runTransform"
+      done()


### PR DESCRIPTION
makeFunctionTransform can be used to transform arbitrary
functions by passing in options.functionNames. This attr
can be either a string or an array of strings. If no
function name is provided the transform falls back to
an require transform.
New function is documented and tested.