### PR TITLE
bump falafel to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "falafel": "^1.0.1",
+    "falafel": "^2.0.0",
     "through": "^2.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,

This PR updates the falafel dependency. falafel 2.0.0 now uses acorn 3 that parse js as ES6 by default. This solves issues like benbria/aliasify#43
