### PR TITLE
add .vue to support vue single file components

### DIFF
--- a/src/skipFile.coffee
+++ b/src/skipFile.coffee
@@ -6,7 +6,8 @@ JS_EXTENSIONS = [
     ".coffee", ".coffee.md", ".litcoffee", # via coffeeify
     "._js", "._coffee", # Streamline.js
     ".jsx", # React
-    ".es", ".es6" # ES6
+    ".es", ".es6", # ES6
+    ".vue" # vue single file components
 ]
 
 isArray = (obj) -> Object.prototype.toString.call( obj ) == '[object Array]'


### PR DESCRIPTION
We use aliasify to require vue version dynamicly in [vue browserify template](https://github.com/vuejs-templates/browserify), which uses browserify-transform-tools to process files.

Everything goes ok except the ".vue" files, which are not recognized as js type and thus are ignored. Also ".vue" single file component is become more and more popular in vue.js ecosystem. So I open this PR to add **.vue** to JS_EXTENSIONS.